### PR TITLE
Set comment link text to avoid confusing comments and grade review comments

### DIFF
--- a/lang/en/assignsubmission_gradereviews.php
+++ b/lang/en/assignsubmission_gradereviews.php
@@ -22,6 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['commentlinktext'] = 'Grade review';
 $string['default'] = 'Enabled by default';
 $string['default_help'] = 'If set, this submission method will be enabled by default for all new assignments.';
 $string['enabled'] = 'Submission gradereviews';

--- a/locallib.php
+++ b/locallib.php
@@ -67,6 +67,7 @@ class assign_submission_gradereviews extends assign_submission_plugin {
         $options->component = 'assignsubmission_gradereviews';
         $options->showcount = true;
         $options->displaycancel = true;
+        $options->linktext = get_string('commentlinktext', 'assignsubmission_gradereviews');
 
         $gradereview = new comment($options);
         $gradereview->set_view_permission(true);


### PR DESCRIPTION
Changes link text on grade review comments to avoid confusion. Fixes #4.
Requires translations.